### PR TITLE
Fix the tokenizer template error

### DIFF
--- a/src/distillflow/datasets/loader.py
+++ b/src/distillflow/datasets/loader.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import TypedDict, Optional, Dict, Any, List
 
 import numpy as np
-from datasets import DatasetDict, load_dataset, Dataset, concatenate_datasets, interleave_datasets
+from datasets import DatasetDict, load_dataset, Dataset, concatenate_datasets, interleave_datasets, IterableDataset
 from transformers import PreTrainedTokenizer
 
 from .args import DatasetArgs, DataArgs
@@ -74,7 +74,11 @@ def _load_single_dataset(
             )
 
         if data_args.text_field is not None:
-            dataset = dataset.map(partial(to_text, data_args.text_field, tokenizer), batched=False, remove_columns=dataset.column_names,
+            if isinstance(dataset, IterableDataset):
+                dataset = dataset.map(partial(to_text, data_args.text_field, tokenizer), batched=False,
+                                      remove_columns=dataset.column_names)
+            else:
+                dataset = dataset.map(partial(to_text, data_args.text_field, tokenizer), batched=False, remove_columns=dataset.column_names,
                                   load_from_cache_file=dataset_args.load_from_cache_file)
         return dataset
 

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -11,7 +11,6 @@ from distillflow.common import get_current_device
 from distillflow.config.validator import print_validation_error
 from distillflow.datasets.loader import get_dataset
 from distillflow.model.loader import load_model
-from distillflow.model.tokenizer import load_tokenizer
 from distillflow.trainer.attention_distillation import AttentionTrainer
 from distillflow.trainer.layers_distillation import LayersTrainer
 from distillflow.trainer.logits_distillation import LogitsTrainer

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -11,6 +11,7 @@ from distillflow.common import get_current_device
 from distillflow.config.validator import print_validation_error
 from distillflow.datasets.loader import get_dataset
 from distillflow.model.loader import load_model
+from distillflow.model.tokenizer import load_tokenizer
 from distillflow.trainer.attention_distillation import AttentionTrainer
 from distillflow.trainer.layers_distillation import LayersTrainer
 from distillflow.trainer.logits_distillation import LogitsTrainer
@@ -56,15 +57,6 @@ def main():
 
     # Handle device
     device = get_current_device()
-
-    # Load tokenizer and dataset
-    tokenizer_template = config.tokenizer.template
-    tokenizer = load_tokenizer(config.student_model, template=tokenizer_template)
-
-    def tokenizer_function(examples):
-        return tokenizer(examples[config.data.text_field], truncation=True, max_length=config.distill.max_seq_length,
-                                 padding="max_length", return_tensors="pt")
-
 
     accelerator = None
     student_plugin = DeepSpeedPlugin(hf_ds_config=config.student_model.deepspeed_config)


### PR DESCRIPTION
The trainer is failing because of the following error surfaced in the following issue 
https://github.com/horus-ai-labs/DistillFlow/issues/9

```
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
Traceback (most recent call last):
  File "/Users/akashdeepjassal/Desktop/exp/DistillFlow/src/trainer.py", line 119, in <module>
    main()
  File "/Users/akashdeepjassal/Desktop/exp/DistillFlow/src/trainer.py", line 61, in main
    tokenizer_template = config.tokenizer.template
                         ^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/distill/lib/python3.12/site-packages/pydantic/main.py", line 891, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'Config' object has no attribute 'tokenizer' 
```

This block is duplicated on line 85 and no longer required.